### PR TITLE
Add ICDA results to leaderboard for few-shot intent detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Then the checkpoints are downloaded into  `Your_folder_name`
 |[CONVBERT+MLM+Example+Observers](https://arxiv.org/abs/2010.08684)  (NAACL 2021)     | - | - | - |
 |[DNNC](https://www.aclweb.org/anthology/2020.emnlp-main.411/) (EMNLP 2020)              | 80.40 | 91.02 | 80.46 | 
 |[CPFT](https://arxiv.org/pdf/2109.06349.pdf) (EMNLP 2021) |80.86| 92.34 | 82.03|
+|[ICDA](https://arxiv.org/abs/2302.05096) (EACL 2023) |84.01| 92.62 | 82.45|
 
 
 **10-shot learning**
@@ -203,6 +204,7 @@ Then the checkpoints are downloaded into  `Your_folder_name`
 |[CONVBERT+MLM+Example+Observers](https://arxiv.org/abs/2010.08684) (NAACL 2021) | 85.95 | 93.97 | 86.28 |
 |[DNNC](https://www.aclweb.org/anthology/2020.emnlp-main.411/) (EMNLP 2020)              | 86.71 | 93.76 | 84.72 |
 |[CPFT](https://arxiv.org/pdf/2109.06349.pdf) (EMNLP 2021) |87.20| 94.18 | 87.13|
+|[ICDA](https://arxiv.org/abs/2302.05096) (EACL 2023) |89.79| 94.84 | 87.41|
 
 `Note:` the 5-shot learning results of RoBERTa+Classifier, DNNC and CPFT, and the 10-shot learning results of all the models are reported by the paper authors. 
 


### PR DESCRIPTION
Hi there,

I hope you're doing well. I would like to contribute to the leaderboard for few-shot intent detection that is listed in the README of this GitHub repo. I have achieved state-of-the-art results using a new method called ICDA (https://arxiv.org/pdf/2302.05096.pdf), and I would like to add my results to the leaderboard.

I have made the necessary changes to the README, and you can find my results listed under the ICDA method. I have also included a link to my paper for reference.

Thank you for maintaining this repository, and I hope that my contribution will be helpful to others in the community.

Best regards,
Yen-Ting