### PR TITLE
[refactor] Fix misalignment in BANKING77-OOS/id-oos/test/seq.in

### DIFF
--- a/Datasets/BANKING77-OOS/id-oos/test/seq.in
+++ b/Datasets/BANKING77-OOS/id-oos/test/seq.in
@@ -237,7 +237,6 @@ my card's frozen, what can i do?
 how can i unlock the pin?
 since my pin is blocked, would you help me unblock it?
 my pin is not working and i need assistance.
-
 where can i get my pin unblocked?
 are contactless payments enabled on my new card?
 my contanctless has stopped working
@@ -358,7 +357,7 @@ is there a maximum i can top up?
 how can i tell if there is a top-up limit?
 do you have any restrictions to my top-up?
 as for limits are top ups included?
-which cards and currencies do you support?
+what are the top-up limits?
 where can i obtain my virtual card?
 how do you get a virtual card?
 where can i find a virtual card?
@@ -415,8 +414,6 @@ what places can i use my card?
 is my card accepted everywhere?
 what places will accept my card for payment?
 does this card work everywhere?
-
-
 what businesses accept this card?
 where can i use my card?
 which outlets accept my card?
@@ -438,9 +435,9 @@ what places will accept my card?
 can i use my card anywere?
 will any business take this card?
 will filling stations accept my card?
-do i have to verify my identity?
-why do you need to know so much about me
-why did i need to verfiy my identity?
+where am i able to use the card?
+what can i use my card to pay for?
+who accepts my card?
 i cannot verify my identity
 i do not have what is required to prove my identity
 why doesn't the app believe i am who i say i am?
@@ -622,7 +619,6 @@ which atm's will accept my card?
 at what atms am i able to use the card?
 can i use my card at any atms?
 can i get cash with this card anywhere?
-
 which atms accept this card?
 can someone please assist me with finding my nearest atm?
 are there any atm machines near me?
@@ -638,10 +634,10 @@ what atms will accept this type of card?
 where can i find an atm to use this card?
 at which atms can i use this card?
 are there certain atms that i can use this card at?
-someone has taken my money and i don't know who
-i was charged on my account that shouldn't be there.
-there's a direct debit i wish to dispute
-why was my account deducted from a seller when i didn't approve of it?
+do you know the closest atm?
+can i use this card at an atm?
+is there places where i can't withdraw money?
+locations to withdraw money
 what do i do if i forget my passcode?  because i did.
 i can't find my password
 how do i retrieve my passcode?
@@ -678,10 +674,10 @@ how do i reset the passcode?
 what should i do if i forgot my passcode?
 my passcode doesn't work
 tell me how to reset the passcode.
-i am still waiting for a money transfer to show
-my transfer hasn't gone through yet.
-i am confused as to why my transfer could still be pending.
-how long does it take for a money transfer to show?
+i need a new passcode.
+i don't have my access code for the app.
+can you tell me what to do to reset my passcode?
+what is the code i need to get into the app?
 can you remove my account please?
 i want to close an account but im not sure about setting up a new one in the future, what do you recommend
 my account needs to be deleted.
@@ -758,10 +754,10 @@ my card has been swallowed by an atm
 i was taking out funds and was unable to regain my card.
 what should i do with my atm that got stuck?
 the atm at metro bank on high st. kensington didn't return my card. what should i do now that the bank is closed?
-there is more than one of the same transaction on my account.
-i have a duplicate payment showing
-i made a payment that got charged twice instead of once.
-what are my remedies if i think i was charged twice for the same expense?
+the atm won't give back my card
+i was at an atm and it swallowed my card.
+wtf??? i tried to withdraw some money at a metro bank on high st. kensington and without any notice it disappeared in the machine. the bank was already closed so i couldn't do anything. how do i get it back?
+what happens if my card is stuck in the atm?
 can i verify the source of my funds?
 i want information about the source of funds.
 where are my funds being sourced from?
@@ -798,10 +794,10 @@ where can i see the source of my money?
 what is source of my funds, need to verify
 where do my funds come from?
 how can i check the source of my fund?
-i was charged for something i didn't expect
-i purchased some makeup through a site in china, and i was under the impression that when i make transfers there is no fee.  why am i seeing this fee now?  i am not happy about this at all.
-i got charged and extra fee when i transferred money so why was i charged?
-can you explain the transfer fee to me?
+how can i see my source of funds?
+how do i become aware of where my funds come from?
+where does all this money come from though?
+what do i need to do to verify the source of my funds?
 will salary be received through this?
 how can i get paid in a different currency?
 can i receive my salary in a currency other than what it is deposited in?
@@ -838,10 +834,10 @@ do you know if i can use this for my salary?
 how do i get my paycheck through this?
 can i transfer my salary if it's in a different currency?
 can i get paid in a different currency?
-why didn't my transfer go through?
-i've attempted to do a very standard transfer and have tried 5 times at this point. can you tell me what the issue is? is the system down?
-can you provide a reason as to why my transfer did not work?
-i tried to transfer money and it did not work.
+is my salary eligible for this?
+my salary is in gbp; how can i note this in the app?
+can i get paid in another currency?
+can i get my paycheck through here?
 can i do a bank transfer to put additional money in my account because i am out of money?
 i'm out of money, can i add money with my bank?
 how do i go forth on transferring money into my account?
@@ -878,10 +874,10 @@ i would like use the bank transfer, but i don't understand the process, can you 
 i want to use bank transfer for topping up my account. how is it handled?
 i checked my account today and it said i was out of money. how do i transfer money into my account?
 how can i transfer money to my account?
-is it possible to give a second card for this account to my daughter?
-my daughter needs a card. can i give her one of mine that's linked to my account?
-my child needs a card, how can i add them to the account i currently have?
-my daughter needs a card, how do i add her?
+i would like to transfer funds from one account to another.
+i'm trying to transfer money into my account.
+i would like to transfer money from my other bank account into this one.
+can i use a bank transfer to refill my account?
 can i top up by cheque?
 how do i top-up using cash?
 can i top up with a cheque?
@@ -918,10 +914,10 @@ can i send a cheque to do my top ups?
 can i top up my account with a cheque?
 i want to do a cash top-up
 i have a cheque here, can i use it to top off my account?
-i need a physical card.
-what are the fees for a physical card?
-how do i get an actual card?
-can i get a real card?
+i want to top-up using cash
+how can i top-up my card?
+can i submit a check or cash payment?
+do you accept checks?
 why is my disposable virtual card being denied?
 my disposable virtual card doesn't seem to work
 my disposable virtual card is broken.
@@ -958,10 +954,10 @@ payments from my disposable virtual card don't work
 my disposable virtual card was rejected by the merchant, please help?
 my virtual card won't work.
 tell me why my virtual disposable card won't work.
-how do you determine your exchange rates because one of yours was off when i got cash
-i used the atm machine to get money out for holiday shopping and saw the outrageous charges. why is that? i would not have used the atm if i had known!
-the cash withdrawal exchange rate is not correct.
-is there a local atm that will provide british pounds, i have no money for my homeward journey and do not feel comfortable waiting until  i arrive in britain. will a withdrawal involve extra charges?
+i need help getting the virtual card to work.
+i was trying to use my virtual card at a merchant and it was rejected. how can i fix this?
+how do i make my virtual card work?
+virtual card is not working for me
 can i get a description of how to use a disposable virtual card
 can i create a disposable virtual card?
 what can you tell me about getting a virtual disposable card?
@@ -998,10 +994,10 @@ where can i get a disposable virtual card?
 will i be able to get a disposable virtual card as well?
 hello! i need to order a disposable virtual card. where can i do that at?
 where do i request a disposable virtual card?
-i would like to exchange currencies, but is there an extra charge to do so?
-does it cost anything for exchanges?
-can i exchange money from abroad without additional costs?
-does it cost to exchange currencies?
+can i get a throw away card
+how many transactions can i make with a disposable card
+what are disposable cards?
+what's the process for getting a disposable virtual card?
 is there a fee for using a european bank card to top up?
 are there any fees for adding money with an international card?
 i was charged when i used a us issued card. why and what cards are free to use to add money
@@ -1038,10 +1034,10 @@ what are the fees of using an international card to add money?
 is there a charge or discount if i use a european bank in a top up?
 is their a fee for top ups?
 can i top up using an international card
-how do i top up with apple pay?
-why isn't my top up working using my saved american express in applepay?
-how do i use the top up app with my apple watch?
-google pay and top up, i want it, can i get it?
+what will happen if i want to add money using an international card? will i run into any fees?
+are there any extra fees for adding money into the international card?
+what are the fees for top ups?
+what are the top up charges for us cards?
 what can i use to verify my identify?
 what do you need to verify my identity?
 i need to verify my identity, but how do i do that?
@@ -1078,3 +1074,7 @@ what do i need to show who i am?
 do i need any kind of documentation for the identity check?
 what will i need for identity verification?
 is there any way to verify who i am?
+is there any documentation needed for the identity check?
+what all am i required to show for the identity check?
+what do i do for the identity check?
+what do i need to do to verify my identity?


### PR DESCRIPTION
Hi there,

I hope you're doing well.

This PR corrects the correspondence between the blank lines and the errors in `BANKING77-OOS/id-oos/test/seq.in` by referring to the sequence order from `BANKING77/test/label`.

Previously, the blank lines and error entries in `seq.in` were misaligned, likely due to discrepancies when constructing the OOS set. By using the sequence corresponding to `BANKING77/test/label` as a reference, I have realigned the entries so that the blank lines correctly match the errors they are intended to represent.

This fix ensures that the test data is consistent and that downstream evaluations relying on correct blank/error positioning are accurate.

I appreciate your work on this repository and hope my contribution will be useful to the community.

Best regards,  
Francis Lin
